### PR TITLE
Resolves empty block represented by two double quotes

### DIFF
--- a/vdf/__init__.py
+++ b/vdf/__init__.py
@@ -110,6 +110,11 @@ def parse(fp, mapper=dict, merge_duplicate_keys=True, escaped=True):
             continue
 
         if expect_bracket:
+            # if the line is "" it means the block is empty
+            if line[0:2] == '""':
+                stack.pop()
+                expect_bracket = False
+                continue
             raise SyntaxError("vdf.parse: expected openning bracket",
                               (getattr(fp, 'name', '<%s>' % fp.__class__.__name__), lineno, 1, line))
 


### PR DESCRIPTION
Resolves empty block represented by two double quotes (""). As seen in npc_dota_hero_centaur.txt:
			"damage_reduction"	
			""